### PR TITLE
Fix subtitle save/decrypt routine

### DIFF
--- a/crunchy-xml-decoder/ultimate.py
+++ b/crunchy-xml-decoder/ultimate.py
@@ -170,9 +170,9 @@ def subtitles(eptitle):
 		continue
 	    #subfile = open(eptitle + '.###', 'wb')
 	    subfile = open(os.path.join('export', title + '['+ sublangc + ']' + sublangn + '.###'), 'wb')
-	subfile.write(formattedsubs.encode('utf-8-sig'))
-	subfile.close()
-			#shutil.move(eptitle + '.###', os.path.join(os.getcwd(), 'export', ''))
+            subfile.write(formattedsubs.encode('utf-8-sig'))
+            subfile.close()
+        #shutil.move(eptitle + '.###', os.path.join(os.getcwd(), 'export', ''))
 # ----------
 
 def ultimate(page_url, seasonnum, epnum):


### PR DESCRIPTION
This makes it so it will actually save all the subtitles and also so that it doesn't error if the video in question doesn't have one.