### PR TITLE
Properly fix Premium+ Detection

### DIFF
--- a/crunchy-xml-decoder/login.py
+++ b/crunchy-xml-decoder/login.py
@@ -47,7 +47,7 @@ def login(username, password):
                'login_form[_token]': token}
 
     res_post = session.post('https://www.crunchyroll.com/login', data=payload, headers=headers, allow_redirects = False)
-    if res_post.status_code != 302:
+    if not (res_post.status_code == 302 or (res_post.status_code == 200 and username == '')):
       print 'Login failed'
       sys.exit()
 

--- a/crunchy-xml-decoder/login.py
+++ b/crunchy-xml-decoder/login.py
@@ -22,10 +22,9 @@ def getuserstatus(session=''):
     if re.search(re.escape('      ga(\'set\', \'dimension5\', \'registered\');'), site):
         status = 'Free Member'
     elif re.search(re.escape('      ga(\'set\', \'dimension6\', \'premium\');'), site):
-        if re.search(re.escape('      ga(\'set\', \'dimension6\', \'premiumplus\');'), site):
-            status = 'Premium+ Member'
-        else:
-            status = 'Premium Member'
+        status = 'Premium Member'
+    elif re.search(re.escape('      ga(\'set\', \'dimension6\', \'premiumplus\');'), site):
+        status = 'Premium+ Member'
     if status != 'Guest':
         user1 = re.findall('<a href=\"/user/(.+)\" ', site).pop()
     return [status,user1]


### PR DESCRIPTION
Move the Premium+ check to outside the Premium check (regex is looking for exact match).

This fix was tested against a Free Member, Premium (free trial), Premium+ (30 day pass), and Premium+ (48 hour guest pass) account and should be safe to commit if you want to do so.

The old patch would of broken Premium detection since it didn't look at the right place for it.  Well it would of at least for trials since that one drops "freetrial" in dimension5.  I still need to see a subscribed Premium to know for sure later on but this should be safe no matter what.

EDIT: Paid Premium as "premium" on dimension5.  This is consistent with my theory however the current method works fine.  If we want a more sure fire method then there is another insert later on that flags premium and premium+ directly.