### PR TITLE
Attempt to prevent a possible memory leak that can cause downloads to stall.

### DIFF
--- a/crunchy-xml-decoder/ultimate.py
+++ b/crunchy-xml-decoder/ultimate.py
@@ -13,6 +13,7 @@ import re
 import shutil
 import subprocess
 import sys
+import gc
 #import HTMLParser
 
 import altfuncs
@@ -352,6 +353,8 @@ Booting up...
         #os.remove(os.path.join(os.getcwd(), 'export', '') + title + '.###')
         for f in subtitle_input:
             os.remove(f)
+    #Try to cleanup memory after each episode in an attempt to prevent a possible leak.
+    gc.collect()
     print 'Cleanup Complete'
 
 # ----------


### PR DESCRIPTION
Add a gc.collect() call after file cleanup is done and before announcing that it is done.  I observed that it would fill up ram after several episodes so this is an attempt to prevent the scenario by having Python do a force garbage collection after each episode is done.